### PR TITLE
carlosaguilarmelchor remplacé partout par TLS-SEC

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
           <li><a class="buttons github" href="https://github.com/TLS-SEC/tls-sec">View On GitHub</a></li>
         </ul>
 
-        <p class="header">Ce site est entrenu par l'équipe enseignante de <a class="header name" href="https://github.com/TLS-SEC">TLS-SEC</a></p>
+        <p class="header">Ce site est géré par l'organisation <a class="header name" href="https://github.com/TLS-SEC">TLS-SEC</a> ou participent enseignants et étudiants</p>
 
 
       </header>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
-    <title>TLS-SEC by carlosaguilarmelchor</title>
+    <title>TLS-SEC</title>
 
     <link rel="stylesheet" href="stylesheets/styles.css">
     <link rel="stylesheet" href="stylesheets/github-light.css">
@@ -20,12 +20,12 @@
         <p class="header">La formation en sécurité de l&#39;information de Toulouse Ingénierie</p>
 
         <ul>
-          <li class="download"><a class="buttons" href="https://github.com/carlosaguilarmelchor/tls-sec/zipball/master">Download ZIP</a></li>
-          <li class="download"><a class="buttons" href="https://github.com/carlosaguilarmelchor/tls-sec/tarball/master">Download TAR</a></li>
-          <li><a class="buttons github" href="https://github.com/carlosaguilarmelchor/tls-sec">View On GitHub</a></li>
+          <li class="download"><a class="buttons" href="https://github.com/TLS-SEC/tls-sec/zipball/master">Download ZIP</a></li>
+          <li class="download"><a class="buttons" href="https://github.com/TLS-SEC/tls-sec/tarball/master">Download TAR</a></li>
+          <li><a class="buttons github" href="https://github.com/TLS-SEC/tls-sec">View On GitHub</a></li>
         </ul>
 
-        <p class="header">This project is maintained by <a class="header name" href="https://github.com/carlosaguilarmelchor">carlosaguilarmelchor</a></p>
+        <p class="header">Ce site est entrenu par l'équipe enseignante de <a class="header name" href="https://github.com/TLS-SEC">TLS-SEC</a></p>
 
 
       </header>


### PR DESCRIPTION
Modification des liens, du titre et du message qui attribuait la création/maintien à @carlosaguilarmelchor, remplacé par l'organisation @TLS-SEC
