### PR TITLE
DL de zip/tar remplacé par syllabus/plaquette. Fichiers blob remplaés par raw

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,9 +20,9 @@
         <p class="header">La formation en sécurité de l&#39;information de Toulouse Ingénierie</p>
 
         <ul>
-          <li class="download"><a class="buttons" href="https://github.com/carlosaguilarmelchor/tls-sec/zipball/master">Download ZIP</a></li>
-          <li class="download"><a class="buttons" href="https://github.com/carlosaguilarmelchor/tls-sec/tarball/master">Download TAR</a></li>
-          <li><a class="buttons github" href="https://github.com/carlosaguilarmelchor/tls-sec">View On GitHub</a></li>
+          <li class="download"><a class="buttons" href="https://github.com/TLS-SEC/tls-sec/raw/master/syllabus.pdf">Syllabus</a></li>
+          <li class="download"><a class="buttons" href="https://github.com/TLS-SEC/tls-sec/raw/master/plaquette.pdf">Plaquette</a></li>
+          <li><a class="buttons github" href="https://github.com/carlosaguilarmelchor/tls-sec">Voir Sur GitHub</a></li>
         </ul>
 
         <p class="header">This project is maintained by <a class="header name" href="https://github.com/carlosaguilarmelchor">carlosaguilarmelchor</a></p>
@@ -52,7 +52,7 @@
 <h3>
 <a id="ressources" class="anchor" href="#ressources" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Ressources</h3>
 
-<p>Voici un <a href="https://github.com/TLS-SEC/tls-sec/blob/master/syllabus.pdf">syllabus</a> et une <a href="https://github.com/TLS-SEC/tls-sec/blob/master/plaquette.pdf">plaquette</a> décrivant la formation.</p>
+<p>Voici un <a href="https://github.com/TLS-SEC/tls-sec/raw/master/syllabus.pdf">syllabus</a> et une <a href="https://github.com/TLS-SEC/tls-sec/raw/master/plaquette.pdf">plaquette</a> décrivant la formation.</p>
       </section>
       <footer>
         <p><small>Hosted on <a href="https://pages.github.com">GitHub Pages</a> using the Dinky theme</small></p>


### PR DESCRIPTION
Maintenant à gauche au lieu de télécharger un zip/tar avec tout le dépôt on peut télécharger bien visiblement le syllabus ou la plaquette.
